### PR TITLE
add fixes for torch-1.0.0, new h5py

### DIFF
--- a/structural-probes/data.py
+++ b/structural-probes/data.py
@@ -171,7 +171,7 @@ class SimpleDataset:
     single_layer_features_list = []
     for index in sorted([int(x) for x in indices]):
       observation = observations[index]
-      feature_stack = hf[str(index)].value
+      feature_stack = hf[str(index)]
       single_layer_features = feature_stack[layer_index]
       assert single_layer_features.shape[0] == len(observation.sentence)
       single_layer_features_list.append(single_layer_features)
@@ -389,7 +389,7 @@ class BERTDataset(SubwordDataset):
     single_layer_features_list = []
     for index in tqdm(sorted([int(x) for x in indices]), desc='[aligning embeddings]'):
       observation = observations[index]
-      feature_stack = hf[str(index)].value
+      feature_stack = hf[str(index)]
       single_layer_features = feature_stack[elmo_layer]
       tokenized_sent = subword_tokenizer.wordpiece_tokenizer.tokenize('[CLS] ' + ' '.join(observation.sentence) + ' [SEP]')
       untokenized_sent = observation.sentence

--- a/structural-probes/loss.py
+++ b/structural-probes/loss.py
@@ -65,7 +65,7 @@ class L1DepthLoss(nn.Module):
         batch_loss: average loss in the batch
         total_sents: number of sentences in the batch
     """
-    total_sents = torch.tensor(sum((length_batch != 0).float()), device=self.args['device'])
+    total_sents = torch.sum(length_batch != 0).float()
     labels_1s = (label_batch != -1).float()
     predictions_masked = predictions * labels_1s
     labels_masked = label_batch * labels_1s

--- a/structural-probes/reporter.py
+++ b/structural-probes/reporter.py
@@ -105,7 +105,7 @@ class WordPairReporter(Reporter):
         words = observation.sentence
         length = int(length)
         prediction = prediction[:length,:length]
-        label = label[:length,:length]
+        label = label[:length,:length].cpu()
         spearmanrs = [spearmanr(pred, gold) for pred, gold in zip(prediction, label)]
         lengths_to_spearmanrs[length].extend([x.correlation for x in spearmanrs])
     mean_spearman_for_each_length = {length: np.mean(lengths_to_spearmanrs[length]) 
@@ -136,7 +136,7 @@ class WordPairReporter(Reporter):
           length_batch, observation_batch):
         length = int(length)
         prediction = prediction[:length,:length]
-        label = label[:length,:length]
+        label = label[:length,:length].cpu()
         words = observation.sentence
         fontsize = 5*( 1 + np.sqrt(len(words))/200)
         plt.clf()
@@ -194,7 +194,7 @@ class WordPairReporter(Reporter):
         length = int(length)
         assert length == len(observation.sentence)
         prediction = prediction[:length,:length]
-        label = label[:length,:length]
+        label = label[:length,:length].cpu()
 
         gold_edges = prims_matrix_to_edges(label, words, poses)
         pred_edges = prims_matrix_to_edges(prediction, words, poses)
@@ -266,7 +266,7 @@ class WordReporter(Reporter):
         words = observation.sentence
         length = int(length)
         prediction = prediction[:length]
-        label = label[:length]
+        label = label[:length].cpu()
         sent_spearmanr = spearmanr(prediction, label)
         lengths_to_spearmanrs[length].append(sent_spearmanr.correlation)
     mean_spearman_for_each_length = {length: np.mean(lengths_to_spearmanrs[length]) 
@@ -303,7 +303,7 @@ class WordReporter(Reporter):
           prediction_batch, label_batch,
           length_batch, observation_batch):
         length = int(length)
-        label = list(label[:length])
+        label = list(label[:length].cpu())
         prediction = prediction.data[:length]
         words = observation.sentence
         poses = observation.xpos_sentence
@@ -333,7 +333,7 @@ class WordReporter(Reporter):
         plt.clf()
         length = int(length)
         prediction = prediction[:length]
-        label = label[:length]
+        label = label[:length].cpu()
         words = observation.sentence
         fontsize = 6
         cumdist = 0


### PR DESCRIPTION
### deprecation warning/error fixes for new dependency versions

Looks like in the `torch-1.0.x`, the `labels` tensor is in CUDA mem by the time it hits `reporter.py`, leading to problems when `scipy` forces a conversion of the tensor to `numpy`. Brought to light in #4; this PR should fix that issue.

Further, now `h5py` preferred syntax for accessing data values doesn't use `.value`; using this was emitting a warning for each observation.

Finally, a `sum` call that should have been a `torch.sum` call was requiring a further wrapping in `torch.tensor`, which is a mess and was spitting errors; this has been fixes.