### PR TITLE
Fix example crashing

### DIFF
--- a/structural-probes/run_demo.py
+++ b/structural-probes/run_demo.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
     torch.manual_seed(cli_args.seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-  yaml_args= yaml.load(open(cli_args.experiment_config))
+  yaml_args= yaml.safe_load(open(cli_args.experiment_config))
   run_experiment.setup_new_experiment_dir(cli_args, yaml_args, cli_args.results_dir)
   device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
   yaml_args['device'] = device

--- a/structural-probes/run_experiment.py
+++ b/structural-probes/run_experiment.py
@@ -235,7 +235,7 @@ if __name__ == '__main__':
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
 
-  yaml_args= yaml.load(open(cli_args.experiment_config))
+  yaml_args= yaml.safe_load(open(cli_args.experiment_config))
   setup_new_experiment_dir(cli_args, yaml_args, cli_args.results_dir)
   device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
   yaml_args['device'] = device

--- a/structural-probes/run_experiment.py
+++ b/structural-probes/run_experiment.py
@@ -199,7 +199,7 @@ def setup_new_experiment_dir(args, yaml_args, reuse_results_path):
   if reuse_results_path:
     new_root = reuse_results_path
     tqdm.write('Reusing old results directory at {}'.format(new_root))
-    if args.train_probe == -1:
+    if not hasattr(args, 'train_probe') or args.train_probe == -1:
       args.train_probe = 0
       tqdm.write('Setting train_probe to 0 to avoid squashing old params; '
           'explicitly set to 1 to override.')


### PR DESCRIPTION
Based on the instructions in the readme, the example crashed with the following error:

```
Traceback (most recent call last):
  File "/Users/simonchervenak/Documents/GitHub/structural-probes/structural-probes/run_demo.py", line 174, in <module>
    yaml_args= yaml.load(open(cli_args.experiment_config))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: load() missing 1 required positional argument: 'Loader'
```

I updated the code to use `safe_load` to fix this error.